### PR TITLE
Updating output to include more information about the frequencies captured.

### DIFF
--- a/rtlpower.js
+++ b/rtlpower.js
@@ -27,15 +27,26 @@ module.exports = function(RED) {
                 var lines = data.toString().trim().split("\n");
                 for (var i = 0; i < lines.length; i++ ) {
                     var l = lines[i].trim().split(',');
-                    var yr = l.shift();
-                    var ts = l.shift();
-                    var lo = parseInt(l.shift());
-                    var hi = parseInt(l.shift());
-                    var bw = parseInt(l.shift());
-                    var sa = parseInt(l.shift());
-                    var result = l.map(function (x) {
-                        return parseFloat(x, 10);
-                    });
+                    var yr = l.shift(); // Date
+                    var ts = l.shift(); // Time
+                    var lo = parseInt(l.shift()); // Low Hz
+                    var hi = parseInt(l.shift()); // High Hz
+                    var bw = parseInt(l.shift()); // Steps / Bucket Width (Hz)
+                    var sa = parseInt(l.shift()); // Sample size
+
+                    var result = {
+                        "low" : lo,
+                        "high": hi,
+                        "bucket" : bw,
+                        "samples" : sa,
+                        "results" : {}
+                    };
+
+                    for(var x = 0; x < l.length; x++){
+                        var freq = lo + x*bw;
+                        result.results[freq] = parseFloat(l[x]);
+                    }
+
                     node.send({topic:((hi+lo)/2), payload:result});
                 }
             });


### PR DESCRIPTION
Instead of returning an array containing the power values, returns the Low, High frequencies, the bucket width and the samples taken as well as the power levels matched to a frequency.

```
{
    "low":446006250,
    "high":446093750,
    "bucket":10937,
    "samples":3490816,
    "results": { "446006250":-28.53,"446017187":-28.53,"446028124":-28.5,"446039061":-28.49,"446049998":-28.48,"446060935":-28.48,"446071872":-28.53,"446082809":-28.51,"446093746":-28.51}
}
```

Signed-off-by: James Sutton <james.sutton@uk.ibm.com>